### PR TITLE
Connect with existing node via socket

### DIFF
--- a/docker-compose-no-node.yaml
+++ b/docker-compose-no-node.yaml
@@ -10,13 +10,13 @@ networks:
 services:
   ogmios:
     container_name: ogmios
-    image: cardanosolutions/ogmios:v5.5.6-mainnet
+    image: cardanosolutions/ogmios@sha256:da8f612116faa67dfd26be6e50d9622c0e7c75687e1fac37dc7c99fdfa345317
     restart: always
     command:
       - --node-config
       - /node-config/mainnet/config.json
       - --node-socket
-      - /ipc/node.socket
+      - /ipc/${NODE_SOCKET_FILE:-node.socket}
       - --host
       - 0.0.0.0
       - --port
@@ -26,9 +26,6 @@ services:
     volumes:
       - ${PWD}/config:/node-config
       - ${CARDANO_NODE_SOCKET_PATH}:/ipc
-    depends_on:
-      cardano-node:
-        condition: service_healthy
     logging:
       options:
         max-size: 10m
@@ -41,7 +38,7 @@ services:
       - --node-config
       - /node-config/mainnet/config.json
       - --node-socket
-      - /ipc/node.socket
+      - /ipc/${NODE_SOCKET_FILE:-node.socket}
       - --host
       - 0.0.0.0
       - --port
@@ -59,9 +56,6 @@ services:
       - ${KUPO_DATA_FOLDER:-$PWD/kupo-data}:/data
       - ${PWD}/config:/node-config
       - ${CARDANO_NODE_SOCKET_PATH}:/ipc
-    depends_on:
-      cardano-node:
-        condition: service_healthy
     logging:
       options:
         max-size: 10m


### PR DESCRIPTION
- Remove dependencies on service no longer present.
- Update ogmios to work with Cardano Node v8.1.1
- Allow configurable name for node socket file.

References https://github.com/easy1staking-com/liqwid-finance-liquidation-bot/issues/1